### PR TITLE
Added 'unsupported' alias for 'supported([BROWSER], false)' including tests.

### DIFF
--- a/lib/browsernizer/config.rb
+++ b/lib/browsernizer/config.rb
@@ -18,8 +18,12 @@ module Browsernizer
       end
     end
 
-    def unsupported(browser)
-      supported(browser, false)
+    def unsupported(names)
+      if names.is_a? Array
+        names.collect {|name| supported(name, false) }
+      else
+        supported(names, false)
+      end
     end
 
     def location(path)

--- a/spec/browsernizer/config_spec.rb
+++ b/spec/browsernizer/config_spec.rb
@@ -27,6 +27,11 @@ describe Browsernizer::Config do
       subject.unsupported "Chrome"
       subject.get_supported[0].version.should be_false
     end
+
+    it "allows to 'unsupport' multiple browsers at once" do
+      subject.unsupported %w(Firefox Chrome)
+      subject.get_supported.should have(2).items
+    end
   end
 
   describe "location(path)" do


### PR DESCRIPTION
I'm using browsernizer the allow only very few browsers which meant I had to "un–support" quite a few. Hence I added an alias `#unsupported` to make this a bit easier. Maybe you find it useful. 
