### PR TITLE
Avoid using default .to_a

### DIFF
--- a/lib/browsernizer/browser_version.rb
+++ b/lib/browsernizer/browser_version.rb
@@ -13,7 +13,7 @@ module Browsernizer
     end
 
     def <=>(other)
-      ([0]*6).zip(to_a, other.to_a).each do |dump, a, b|
+      ([0]*6).zip(to_a, [*other]).each do |dump, a, b|
         r = (a||0) <=> (b||0)
         return r unless r.zero?
       end


### PR DESCRIPTION
Change will remove the warning message:

/gems/browsernizer-0.2.0/lib/browsernizer/browser_version.rb:16: warning: default `to_a' will be obsolete
