### PR TITLE
Fix deprecation warnings when running specs

### DIFF
--- a/spec/browsernizer/router_spec.rb
+++ b/spec/browsernizer/router_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Browsernizer::Router do
 
-  let(:app) { mock() }
+  let(:app) { double }
 
   subject do
     Browsernizer::Router.new(app) do |config|


### PR DESCRIPTION
"DEPRECATION: mock is deprecated. Use double instead."
