### PR TITLE
Relax version dependency of the 'browser' gem

### DIFF
--- a/browsernizer.gemspec
+++ b/browsernizer.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
 
-  s.add_runtime_dependency 'browser', "~> 0.1.4"
+  s.add_runtime_dependency "browser", "> 0.1.4"
 end


### PR DESCRIPTION
Both 1.x and 2.x work fine, so I've allowed them both.
