### PR TITLE
fixes RSpec 3 expect to be false/true to work

### DIFF
--- a/spec/browsernizer/browser_spec.rb
+++ b/spec/browsernizer/browser_spec.rb
@@ -5,12 +5,12 @@ describe Browsernizer::Browser do
   describe "#meets?(requirement)" do
     context "same vendor" do
       it "returns true if version is >= to requirement" do
-        expect(browser("Chrome", "10.0").meets?(browser("Chrome", "10"  ))).to be_true
-        expect(browser("Chrome", "10.0").meets?(browser("Chrome", "10.1"))).to be_false
-        expect(browser("Chrome", "10"  ).meets?(browser("Chrome", " 9.1"))).to be_true
+        expect(browser("Chrome", "10.0").meets?(browser("Chrome", "10"  ))).to be true
+        expect(browser("Chrome", "10.0").meets?(browser("Chrome", "10.1"))).to be false
+        expect(browser("Chrome", "10"  ).meets?(browser("Chrome", " 9.1"))).to be true
       end
       it "returns false if requirement version is set to false" do
-        expect(browser("Chrome", "10"  ).meets?(browser("Chrome", false ))).to be_false
+        expect(browser("Chrome", "10"  ).meets?(browser("Chrome", false ))).to be false
       end
     end
 

--- a/spec/browsernizer/config_spec.rb
+++ b/spec/browsernizer/config_spec.rb
@@ -13,7 +13,7 @@ describe Browsernizer::Config do
 
     it "allows to unsupport browser by using false as version number" do
       subject.supported "Chrome", false
-      expect(subject.get_supported[0].version).to be_false
+      expect(subject.get_supported[0].version).to be false
     end
   end
 
@@ -29,11 +29,11 @@ describe Browsernizer::Config do
       subject.exclude %r{^/assets}
       subject.exclude "/foo/bar.html"
 
-      expect(subject.excluded?("/assets/foo.jpg")).to be_true
-      expect(subject.excluded?("/Assets/foo.jpg")).to be_false
-      expect(subject.excluded?("/prefix/assets/foo.jpg")).to be_false
-      expect(subject.excluded?("/foo/bar.html")).to be_true
-      expect(subject.excluded?("/foo/bar2.html")).to be_false
+      expect(subject.excluded?("/assets/foo.jpg")).to be true
+      expect(subject.excluded?("/Assets/foo.jpg")).to be false
+      expect(subject.excluded?("/prefix/assets/foo.jpg")).to be false
+      expect(subject.excluded?("/foo/bar.html")).to be true
+      expect(subject.excluded?("/foo/bar2.html")).to be false
     end
   end
 

--- a/spec/browsernizer/router_spec.rb
+++ b/spec/browsernizer/router_spec.rb
@@ -27,7 +27,7 @@ describe Browsernizer::Router do
   context "All Good" do
     it "propagates request with updated env" do
       expect(app).to receive(:call) do |env|
-        expect(env['browsernizer']['supported']).to be_true
+        expect(env['browsernizer']['supported']).to be true
         expect(env['browsernizer']['browser']).to eq("Chrome")
         expect(env['browsernizer']['version']).to eq("7.1.1")
       end
@@ -40,7 +40,7 @@ describe Browsernizer::Router do
     context "location not set" do
       it "propagates request with updated env" do
         expect(app).to receive(:call) do |env|
-          expect(env['browsernizer']['supported']).to be_false
+          expect(env['browsernizer']['supported']).to be false
         end
         subject.call(@env)
       end
@@ -83,7 +83,7 @@ describe Browsernizer::Router do
         end
         it "propagates request with updated env" do
           expect(app).to receive(:call) do |env|
-            expect(env['browsernizer']['supported']).to be_false
+            expect(env['browsernizer']['supported']).to be false
           end
           subject.call(@env)
         end
@@ -127,7 +127,7 @@ describe Browsernizer::Router do
 
     it "propagates request" do
       expect(app).to receive(:call) do |env|
-        expect(env['browsernizer']['supported']).to be_true
+        expect(env['browsernizer']['supported']).to be true
       end
       subject.call(@env)
     end


### PR DESCRIPTION
replaces `to be_false|true` with `to be false|true`